### PR TITLE
Encrypting and Decrypting byte arrays instead of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ C# implementation of Rob Napier's RNCryptor
 
 **Note:** This codebase is in early alpha stage. Don't expect it to do much yet.
 
+**Note:** This project was forked from [here](https://github.com/RNCryptor/RNCryptor-cs)
+
+**Changes:** The main change is, you can encrypt any byte array now, not just strings.
+Byte arrays can be encrypted multiple times and still be decrypted.
+
 This project was developed using Mono on Mac OSX. Its compatibility with Windows
 platforms is presently unknown.
 

--- a/RNCryptor.sln
+++ b/RNCryptor.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RNCryptor", "RNCryptor\RNCryptor.csproj", "{D81E4ED0-1EE0-4B8B-9A8D-568201120CB3}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RNCryptor.Test", "RNCryptor.Test\RNCryptor.Test.csproj", "{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,16 +25,6 @@ Global
 		{D81E4ED0-1EE0-4B8B-9A8D-568201120CB3}.Release|Mixed Platforms.Build.0 = Release|x86
 		{D81E4ED0-1EE0-4B8B-9A8D-568201120CB3}.Release|x86.ActiveCfg = Release|x86
 		{D81E4ED0-1EE0-4B8B-9A8D-568201120CB3}.Release|x86.Build.0 = Release|x86
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{3721AA21-26EA-40E9-8BAC-2FAD729B2D0F}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RNCryptor/Decryptor.cs
+++ b/RNCryptor/Decryptor.cs
@@ -6,109 +6,113 @@ using System.Collections.Generic;
 
 namespace RNCryptor
 {
-	public class Decryptor : Cryptor
-	{
+    public class Decryptor : Cryptor
+    {
+        
+        public byte[] Decrypt(byte[] encryptedBytes, string password)
+        {
+            PayloadComponents components = this.unpackEncryptedBase64Data(encryptedBytes);
 
-		public string Decrypt (string encryptedBase64, string password)
-		{
-			PayloadComponents components = this.unpackEncryptedBase64Data (encryptedBase64);
+            if (!this.hmacIsValid(components, password))
+            {
+                return null;
+            }
 
-			if (!this.hmacIsValid (components, password)) {
-				return "";
-			}
+            byte[] key = this.generateKey(components.salt, password);
 
-			byte[] key = this.generateKey (components.salt, password);
+            byte[] plaintextBytes = new byte[0];
 
-			byte[] plaintextBytes = new byte[0];
+            switch (this.aesMode)
+            {
+                case AesMode.CTR:
+                    // Yes, we are "encrypting" here.  CTR uses the same code in both directions.
+                    plaintextBytes = this.encryptAesCtrLittleEndianNoPadding(components.ciphertext, key, components.iv);
+                    break;
 
-			switch (this.aesMode) {
-				case AesMode.CTR:
-					// Yes, we are "encrypting" here.  CTR uses the same code in both directions.
-					plaintextBytes = this.encryptAesCtrLittleEndianNoPadding(components.ciphertext, key, components.iv);
-					break;
+                case AesMode.CBC:
+                    plaintextBytes = this.decryptAesCbcPkcs7(components.ciphertext, key, components.iv);
+                    break;
+            }
 
-				case AesMode.CBC:
-					plaintextBytes = this.decryptAesCbcPkcs7(components.ciphertext, key, components.iv);
-					break;
-			}
+            return plaintextBytes;
+        }
 
-			return Encoding.UTF8.GetString(plaintextBytes);
-		}
+        private byte[] decryptAesCbcPkcs7(byte[] encrypted, byte[] key, byte[] iv)
+        {
+            var aes = Aes.Create();
+            aes.Mode = CipherMode.CBC;
+            aes.Padding = PaddingMode.PKCS7;
+            var decryptor = aes.CreateDecryptor(key, iv);
 
-		private byte[] decryptAesCbcPkcs7 (byte[] encrypted, byte[] key, byte[] iv)
-		{
-			var aes = Aes.Create();
-			aes.Mode = CipherMode.CBC;
-			aes.Padding = PaddingMode.PKCS7;
-			var decryptor = aes.CreateDecryptor(key, iv);
+            byte[] plainBytes;
+            using (MemoryStream msDecrypt = new MemoryStream())
+            {
+                using (CryptoStream csDecrypt = new CryptoStream(msDecrypt, decryptor, CryptoStreamMode.Read))
+                {
+                    csDecrypt.Write(encrypted, 0, encrypted.Length);
+                    csDecrypt.FlushFinalBlock();
+                    plainBytes = msDecrypt.ToArray();
+                }
+            }
 
-			string plaintext;
-			using (MemoryStream msDecrypt = new MemoryStream(encrypted))
-			{
-				using (CryptoStream csDecrypt = new CryptoStream(msDecrypt, decryptor, CryptoStreamMode.Read))
-				{
-					using (StreamReader srDecrypt = new StreamReader(csDecrypt))
-					{
-						plaintext = srDecrypt.ReadToEnd();
-					}
-				}
-			}
+            return plainBytes;
+        }
 
-            return TextEncoding.GetBytes(plaintext);
-		}
+        private PayloadComponents unpackEncryptedBase64Data(byte[] encryptedBytes)
+        {
+            List<byte> binaryBytes = new List<byte>();
+            binaryBytes.AddRange(encryptedBytes);
 
-		private PayloadComponents unpackEncryptedBase64Data (string encryptedBase64)
-		{
-			List<byte> binaryBytes = new List<byte>();
-			binaryBytes.AddRange (Convert.FromBase64String (encryptedBase64));
+            PayloadComponents components;
+            int offset = 0;
 
-			PayloadComponents components;
-			int offset = 0;
+            components.schema = binaryBytes.GetRange(0, 1).ToArray();
+            offset++;
 
-			components.schema = binaryBytes.GetRange(0, 1).ToArray();
-			offset++;
+            this.configureSettings((Schema)binaryBytes[0]);
 
-			this.configureSettings ((Schema)binaryBytes [0]);
-			
-			components.options = binaryBytes.GetRange (1, 1).ToArray();
-			offset++;
+            components.options = binaryBytes.GetRange(1, 1).ToArray();
+            offset++;
 
-			components.salt = binaryBytes.GetRange (offset, Cryptor.saltLength).ToArray();
-			offset += components.salt.Length;
-			
-			components.hmacSalt = binaryBytes.GetRange(offset, Cryptor.saltLength).ToArray();
-			offset += components.hmacSalt.Length;
-			
-			components.iv = binaryBytes.GetRange(offset, Cryptor.ivLength).ToArray();
-			offset += components.iv.Length;
-			
-			components.headerLength = offset;
-			
-			components.ciphertext = binaryBytes.GetRange (offset, binaryBytes.Count - Cryptor.hmac_length - components.headerLength).ToArray();
-			offset += components.ciphertext.Length;
+            components.salt = binaryBytes.GetRange(offset, Cryptor.saltLength).ToArray();
+            offset += components.salt.Length;
 
-			components.hmac = binaryBytes.GetRange (offset, Cryptor.hmac_length).ToArray();
-			
-			return components;
+            components.hmacSalt = binaryBytes.GetRange(offset, Cryptor.saltLength).ToArray();
+            offset += components.hmacSalt.Length;
 
-		}
+            components.iv = binaryBytes.GetRange(offset, Cryptor.ivLength).ToArray();
+            offset += components.iv.Length;
 
-		private bool hmacIsValid (PayloadComponents components, string password)
-		{
-			byte[] generatedHmac = this.generateHmac (components, password);
+            components.headerLength = offset;
 
-			if (generatedHmac.Length != components.hmac.Length) {
-				return false;
-			}
+            components.ciphertext = binaryBytes.GetRange(offset, binaryBytes.Count - Cryptor.hmac_length - components.headerLength).ToArray();
+            offset += components.ciphertext.Length;
 
-			for (int i = 0; i < components.hmac.Length; i++) {
-				if (generatedHmac[i] != components.hmac[i]) {
-					return false;
-				}
-			}
-			return true;
-		}
+            components.hmac = binaryBytes.GetRange(offset, Cryptor.hmac_length).ToArray();
 
-	}
+            return components;
+
+        }
+
+        private bool hmacIsValid(PayloadComponents components, string password)
+        {
+            byte[] generatedHmac = this.generateHmac(components, password);
+
+            if (generatedHmac.Length != components.hmac.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < components.hmac.Length; i++)
+            {
+                if (generatedHmac[i] != components.hmac[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+    }
 }
 

--- a/RNCryptor/encryptor.cs
+++ b/RNCryptor/encryptor.cs
@@ -9,16 +9,15 @@ namespace RNCryptor
 	{
 		private Schema defaultSchemaVersion = Schema.V2;
 
-		public string Encrypt (string plaintext, string password)
+		public byte[] Encrypt (byte[] plainBytes, string password)
 		{
-			return this.Encrypt (plaintext, password, this.defaultSchemaVersion);
+			return this.Encrypt (plainBytes, password, this.defaultSchemaVersion);
 		}
 
-		public string Encrypt (string plaintext, string password, Schema schemaVersion)
+		public byte[] Encrypt (byte[] plainBytes, string password, Schema schemaVersion)
 		{
 			this.configureSettings (schemaVersion);
-
-            byte[] plaintextBytes = TextEncoding.GetBytes(plaintext);
+            
 
 			PayloadComponents components = new PayloadComponents();
 			components.schema = new byte[] {(byte)schemaVersion};
@@ -31,11 +30,11 @@ namespace RNCryptor
 
 			switch (this.aesMode) {
 				case AesMode.CTR:
-					components.ciphertext = this.encryptAesCtrLittleEndianNoPadding(plaintextBytes, key, components.iv);
+					components.ciphertext = this.encryptAesCtrLittleEndianNoPadding(plainBytes, key, components.iv);
 					break;
 					
 				case AesMode.CBC:
-					components.ciphertext = this.encryptAesCbcPkcs7(plaintextBytes, key, components.iv);
+					components.ciphertext = this.encryptAesCbcPkcs7(plainBytes, key, components.iv);
 					break;
 			}
 
@@ -46,7 +45,7 @@ namespace RNCryptor
 			binaryBytes.AddRange (components.ciphertext);
 			binaryBytes.AddRange (components.hmac);
 
-			return Convert.ToBase64String(binaryBytes.ToArray());
+            return binaryBytes.ToArray();
 		}
 
 		private byte[] encryptAesCbcPkcs7 (byte[] plaintext, byte[] key, byte[] iv)


### PR DESCRIPTION
All byte arrays can be now encrypted and decrypted. 
This was tested on text and image files. 
Multiple encrypts and decrypts work too.

Test project has been unloaded from the solution.
